### PR TITLE
Wait for next block after submitting transaction

### DIFF
--- a/src/FakePAB/CardanoCLI.hs
+++ b/src/FakePAB/CardanoCLI.hs
@@ -91,6 +91,7 @@ data Tip = Tip
   deriving stock (Show, Generic)
   deriving anyclass (JSON.FromJSON)
 
+-- | Getting information of the latest block
 queryTip :: Config -> IO Tip
 queryTip config =
   callCommand

--- a/src/FakePAB/Constraints.hs
+++ b/src/FakePAB/Constraints.hs
@@ -52,6 +52,9 @@ submitTx config lookups constraints = do
       logRecipientsUtxos config tx
       pure result
 
+{- | Wait for at least n slots. The slot number only changes when a new block is appended to the chain
+ so it waits for at least one block
+-}
 waitNSlots :: Config -> Integer -> IO ()
 waitNSlots config n = do
   tip <- queryTip config

--- a/src/FakePAB/Constraints.hs
+++ b/src/FakePAB/Constraints.hs
@@ -44,6 +44,8 @@ submitTx config lookups constraints = do
       logRecipientsUtxos config tx
       result <- submitScript config unbalancedTx
       -- Wait 40 seconds for the next block
+
+      putStrLn "Tx submitted, waiting for next block..."
       waitNSlots config 1
       logRecipientsUtxos config tx
       pure result
@@ -54,13 +56,11 @@ submitTx config lookups constraints = do
 waitNSlots :: Config -> Integer -> IO ()
 waitNSlots config n = do
   tip <- queryTip config
-  print tip
   waitNSlots' tip.slot
   where
     waitNSlots' refSlot = do
       threadDelay 10_000_000
       tip' <- queryTip config
-      print tip'
       unless (tip'.slot > refSlot + n) $ waitNSlots' refSlot
 
 -- | Prints all utxos for all the recipients of a transaction


### PR DESCRIPTION
This PR replaces the fixed wait time, that occurs after submitting transaction, with a `waitNSlots` call. This is implemented by fetching the chain tip at 10 second intervals until the slot number has reached the desired value.

Solves https://github.com/mlabs-haskell/CardStarter-bulk-airdrop-script/issues/5
