### PR TITLE
Multi asset class drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Usage: token-airdrop (--mainnet | --testnet-magic NATURAL)
 - `own-pub-key-hash`: PubKeyHash of the address holding the tokens to be distributed
 - `signing-key-file`: Signing key file of the above PubKeyHash. This will default to `./config/server.skey`
 - `asset-class`: Token asset class (overrides beneficiaries file config)
+- `drop-amount`: Amount of tokens to send to each beneficiary (overrides beneficiaries file config)
 - `beneficiaryPerTx`: This controls how many transaction outputs we batch together. In case the tranaction exceeds the size limit, try to change this value
 - `dryRun`: Builds transactions without actually submitting them on chain
 - `min-lovelaces`: Minimun lovelace amount for each utxo (change this it you get a Minimum required UTxO error)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This file is structured as one receipient per line, with the following format:
 `address amount currencySymbol.tokenName`
 
 - If the `use-pub-key-hashes` flag is set, the addresses become pub key hashes
-- If the `asset-class` and/or `drop-amoun` option is present, the values specified on the cli take precedence over the ones in the file (in this case these fields are optional, however the )
+- If the `asset-class` and/or `drop-amount` option is present, the values specified on the cli take precedence over the ones in the file (in this case these fields are optional, however the )
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This airdrop utility script is provided on an open-source basis courtesy of Card
 cabal run token-airdrop -- --testnet-magic 1097911063 \
   --own-pub-key-hash 0f45aaf1b2959db6e5ff94dbb1f823bf257680c3c723ac2d49f97546 \
   --asset-class 1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e.testToken \
+  --drop-amount 4
   --beneficiaries-per-tx 200 \
   --min-lovelaces 1379280 \
   --fees 70921796 \
@@ -27,14 +28,13 @@ cabal run token-airdrop -- --testnet-magic 1097911063 \
 ```
 Usage: token-airdrop (--mainnet | --testnet-magic NATURAL)
                      [--protocol-params-file ARG]
-                     --asset-class CURRENCY_SYMBOL.TOKEN_NAME
-                     [--beneficiaries-file FILENAME]
-                     --own-pub-key-hash PUB_KEY_HASH
+                     [--beneficiaries-file FILENAME] [--use-pub-key-hashes]
+                     (--own-address ADDRESS | --own-pub-key-hash PUB_KEY_HASH)
                      [--signing-key-file FILENAME]
-                     --beneficiaries-per-tx NATURAL
-                     [--dry-run]
-                     --min-lovelaces NATURAL
-                     --fees NATURAL
+                     [--asset-class CURRENCY_SYMBOL.TOKEN_NAME]
+                     [--drop-amount NATURAL] --beneficiaries-per-tx NATURAL
+                     [--dry-run] --min-lovelaces NATURAL --fees NATURAL
+  CLI tool to simplify sending native tokens to multiple users
 ```
 
 - `mainnet` OR `testnet-magic NATURAL`: This should match whichever node you have set up
@@ -43,6 +43,7 @@ Usage: token-airdrop (--mainnet | --testnet-magic NATURAL)
 - `use-pub-key-hashes`: Sets the beneficiary file to accept PubKeyHashes over addresses
 - `own-pub-key-hash`: PubKeyHash of the address holding the tokens to be distributed
 - `signing-key-file`: Signing key file of the above PubKeyHash. This will default to `./config/server.skey`
+- `asset-class`: Token asset class (overrides beneficiaries file config)
 - `beneficiaryPerTx`: This controls how many transaction outputs we batch together. In case the tranaction exceeds the size limit, try to change this value
 - `dryRun`: Builds transactions without actually submitting them on chain
 - `min-lovelaces`: Minimun lovelace amount for each utxo (change this it you get a Minimum required UTxO error)
@@ -51,8 +52,10 @@ Usage: token-airdrop (--mainnet | --testnet-magic NATURAL)
 ### Beneficiaries format
 
 This file is structured as one receipient per line, with the following format:  
-`address amount currencySymbol.tokenName`  
-If the `use-pub-key-hashes` flag is set, the addresses become pub key hases
+`address amount currencySymbol.tokenName`
+
+- If the `use-pub-key-hashes` flag is set, the addresses become pub key hashes
+- If the `asset-class` and/or `drop-amoun` option is present, the values specified on the cli take precedence over the ones in the file (in this case these fields are optional, however the )
 
 #### Examples
 
@@ -73,4 +76,3 @@ e58973896cb0ae0273296cd407786e543d24a1c9e17931cc246d1bff 1002 1d6445ddeda578117f
 35530c9f7d13efb3153aef891e583a2980a31d27517ebae1e97c7dab 1003 3ccd653511eec65bbd30c3489f53471b017c829bd97d3a2ae81fb818.testToken
 1c9f9e9d6042266e5978163298d566f98336a308df616bd7285cb592 1004 3ccd653511eec65bbd30c3489f53471b017c829bd97d3a2ae81fb818.testToken
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 # CardStarter Bulk Airdrop Script
+
 This airdrop utility script is provided on an open-source basis courtesy of CardStarter.
 
 ## Usage
 
 ### Simple step-by-step
+
 1. Run cardano-node, and configure cardano-cli (this programs calls the CLI in the background)
 2. Copy the protocol parameters file and the signature key file in the config directory (or change the config)
 3. Create a `config/beneficiaries` file with the recipient addresses or pubkeyhashes (see parameters) and the token amounts they receive divided by a space, as defined [here](#beneficiaries-format)
 4. Run the CLI tool using the parameters defined [here](#command-parameters)
-  For example:
-  ```sh
-  cabal run token-airdrop -- --testnet-magic 1097911063 \
-    --own-pub-key-hash 0f45aaf1b2959db6e5ff94dbb1f823bf257680c3c723ac2d49f97546 \
-    --asset-class 1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e.testToken \
-    --beneficiaries-per-tx 200 \
-    --min-lovelaces 1379280 \
-    --fees 70921796 \
-    --dry-run
-  ```
+   For example:
+
+```sh
+cabal run token-airdrop -- --testnet-magic 1097911063 \
+  --own-pub-key-hash 0f45aaf1b2959db6e5ff94dbb1f823bf257680c3c723ac2d49f97546 \
+  --asset-class 1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e.testToken \
+  --beneficiaries-per-tx 200 \
+  --min-lovelaces 1379280 \
+  --fees 70921796 \
+  --dry-run
+```
 
 ### Command parameters
+
 ```
 Usage: token-airdrop (--mainnet | --testnet-magic NATURAL)
                      [--protocol-params-file ARG]
@@ -27,7 +31,7 @@ Usage: token-airdrop (--mainnet | --testnet-magic NATURAL)
                      [--beneficiaries-file FILENAME]
                      --own-pub-key-hash PUB_KEY_HASH
                      [--signing-key-file FILENAME]
-                     --beneficiaries-per-tx NATURAL 
+                     --beneficiaries-per-tx NATURAL
                      [--dry-run]
                      --min-lovelaces NATURAL
                      --fees NATURAL
@@ -35,7 +39,6 @@ Usage: token-airdrop (--mainnet | --testnet-magic NATURAL)
 
 - `mainnet` OR `testnet-magic NATURAL`: This should match whichever node you have set up
 - `protocol-params-file ARG`: This will default to `./config/protocol.json`
-- `asset-class`: The asset class of the token to be distributed
 - `beneficiaries-file`: The file containig the above beneficiaries format. This will default to `./config/beneficiaries`
 - `use-pub-key-hashes`: Sets the beneficiary file to accept PubKeyHashes over addresses
 - `own-pub-key-hash`: PubKeyHash of the address holding the tokens to be distributed
@@ -46,21 +49,28 @@ Usage: token-airdrop (--mainnet | --testnet-magic NATURAL)
 - `fees`: Transaction fees, this is only used for coin selection, the actual fee is calculated by the cardano-cli
 
 ### Beneficiaries format
+
 This file is structured as one receipient per line, with the following format:  
-`address amount`  
+`address amount currencySymbol.tokenName`  
 If the `use-pub-key-hashes` flag is set, the addresses become pub key hases
+
 #### Examples
+
 Without `use-pub-key-hashes`:
+
 ```
-addr_test1vpzm7yazemjns5plryg9yq9lkv9xzr432e88jsdqprty4fqhcw9d7 1001
-addr_test1vqsk6udkq2a552prwtmpmfs8yqyluxlvgx6zy20tqjsglyctfkjrg 1002
-addr_test1vz0vpcef37gsanrj8mtta9hkhfd3ja5ekq7mdjgays7wzlcwzmvf6 1003
-addr_test1vq85t2h3k22emdh9l72dhv0cywlj2a5qc0rj8tpdf8uh23st77ahh 1004
+addr_test1vpzm7yazemjns5plryg9yq9lkv9xzr432e88jsdqprty4fqhcw9d7 1001 1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e.testToken
+addr_test1vqsk6udkq2a552prwtmpmfs8yqyluxlvgx6zy20tqjsglyctfkjrg 1002 1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e.testToken2
+addr_test1vz0vpcef37gsanrj8mtta9hkhfd3ja5ekq7mdjgays7wzlcwzmvf6 1003 3ccd653511eec65bbd30c3489f53471b017c829bd97d3a2ae81fb818.testToken
+addr_test1vq85t2h3k22emdh9l72dhv0cywlj2a5qc0rj8tpdf8uh23st77ahh 1004 3ccd653511eec65bbd30c3489f53471b017c829bd97d3a2ae81fb818.testToken
 ```
+
 With `use-pub-key-hashes`:
+
 ```
-adfd87319bd09c9e3ea10b251ccb046f87c5440343157e348c3ac7bd 1001
-e58973896cb0ae0273296cd407786e543d24a1c9e17931cc246d1bff 1002
-35530c9f7d13efb3153aef891e583a2980a31d27517ebae1e97c7dab 1003
-1c9f9e9d6042266e5978163298d566f98336a308df616bd7285cb592 1004
+adfd87319bd09c9e3ea10b251ccb046f87c5440343157e348c3ac7bd 1001 1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e.testToken
+e58973896cb0ae0273296cd407786e543d24a1c9e17931cc246d1bff 1002 1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e.testToken2
+35530c9f7d13efb3153aef891e583a2980a31d27517ebae1e97c7dab 1003 3ccd653511eec65bbd30c3489f53471b017c829bd97d3a2ae81fb818.testToken
+1c9f9e9d6042266e5978163298d566f98336a308df616bd7285cb592 1004 3ccd653511eec65bbd30c3489f53471b017c829bd97d3a2ae81fb818.testToken
 ```
+

--- a/src/BeneficiariesFile.hs
+++ b/src/BeneficiariesFile.hs
@@ -3,13 +3,16 @@ module BeneficiariesFile (readBeneficiariesFile, Beneficiary) where
 import Config (Config (..))
 import Control.Monad ((<=<))
 import Data.Aeson.Extras (tryDecode)
+import Data.Attoparsec.Text qualified as Attoparsec
 import Data.Either.Combinators (mapLeft, maybeToRight)
 import Data.Text (Text, lines, words)
 import Data.Text qualified as Text
 import Data.Text.IO (readFile)
 import FakePAB.Address (PubKeyAddress, deserialiseAddress, toPubKeyAddress)
+import FakePAB.UtxoParser qualified as UtxoParser
 import Ledger qualified
 import Ledger.Crypto (PubKeyHash (..))
+import Ledger.Value (AssetClass)
 import PlutusTx.Builtins (toBuiltin)
 import Text.Read (readEither)
 import Prelude hiding (lines, readFile, words)
@@ -17,20 +20,27 @@ import Prelude hiding (lines, readFile, words)
 data Beneficiary = Beneficiary
   { amount :: !Integer
   , address :: !PubKeyAddress
+  , assetClass :: !AssetClass
   }
   deriving stock (Show)
 
 parseContent :: Config -> Text -> Either Text [Beneficiary]
-parseContent conf = traverse (parseBeneficiary conf) . lines
+parseContent conf =
+  mapLeft ("Beneficiaries file parse error: " <>)
+    . traverse (parseBeneficiary conf)
+    . lines
 
 parseBeneficiary :: Config -> Text -> Either Text Beneficiary
 parseBeneficiary conf = toBeneficiary . words
   where
     toBeneficiary :: [Text] -> Either Text Beneficiary
-    toBeneficiary [addr, amt] =
+    toBeneficiary [addr, amt, asset] =
       Beneficiary
         <$> mapLeft (const "Invalid amount") (readEither (Text.unpack amt))
         <*> parseAddress conf.usePubKeys addr
+        <*> mapLeft
+          (const "Invalid asset class")
+          (Attoparsec.parseOnly UtxoParser.assetClassParser asset)
     toBeneficiary _ = Left "Invalid format"
 
 parseAddress :: Bool -> Text -> Either Text PubKeyAddress

--- a/src/CommandLine.hs
+++ b/src/CommandLine.hs
@@ -5,15 +5,12 @@ module CommandLine (execCommand) where
 import Cardano.Api (NetworkId (Mainnet, Testnet), NetworkMagic (..))
 import Config (Config (..))
 import Control.Applicative ((<**>), (<|>))
-import Data.Attoparsec.Text qualified as Attoparsec
 import Data.Either.Combinators (mapLeft)
 import Data.Text qualified as Text
 import FakePAB.Address (deserialiseAddress)
-import FakePAB.UtxoParser qualified as UtxoParser
 import Ledger qualified
 import Ledger.Address (Address)
 import Ledger.Crypto (PubKeyHash)
-import Ledger.Value (AssetClass)
 import Options.Applicative (
   Parser,
   ParserInfo,
@@ -43,7 +40,6 @@ configParser =
   Config
     <$> pNetworkId
     <*> pProtocolParamsFile
-    <*> pAssetClass
     <*> pBeneficiariesFile
     <*> pUsePubKeyHashes
     <*> pOwnAddressOrPubKeyHash
@@ -109,12 +105,6 @@ pSigningKeyFile =
         <> value "./config/server.skey"
         <> metavar "FILENAME"
     )
-
-pAssetClass :: Parser AssetClass
-pAssetClass =
-  option
-    (eitherReader (Attoparsec.parseOnly UtxoParser.assetClassParser . Text.pack))
-    (long "asset-class" <> help "Token asset class" <> metavar "CURRENCY_SYMBOL.TOKEN_NAME")
 
 pBeneficiariesFile :: Parser FilePath
 pBeneficiariesFile =

--- a/src/CommandLine.hs
+++ b/src/CommandLine.hs
@@ -4,7 +4,7 @@ module CommandLine (execCommand) where
 
 import Cardano.Api (NetworkId (Mainnet, Testnet), NetworkMagic (..))
 import Config (Config (..))
-import Control.Applicative ((<**>), (<|>))
+import Control.Applicative (optional, (<**>), (<|>))
 import Data.Attoparsec.Text qualified as Attoparsec
 import Data.Either.Combinators (mapLeft)
 import Data.Text qualified as Text
@@ -47,8 +47,8 @@ configParser =
     <*> pUsePubKeyHashes
     <*> pOwnAddressOrPubKeyHash
     <*> pSigningKeyFile
-    <*> pMaybe pAssetClass
-    <*> pMaybe pDropAmount
+    <*> optional pAssetClass
+    <*> optional pDropAmount
     <*> pBeneficiaryPerTx
     <*> pDryRun
     <*> pMinLovelaces
@@ -163,10 +163,6 @@ pFees =
     ( long "fees" <> help "Transaction fees (used for coin selection)"
         <> metavar "NATURAL"
     )
-
-pMaybe :: Parser a -> Parser (Maybe a)
-pMaybe parser =
-  fmap Just parser <|> pure Nothing
 
 execCommand :: IO Config
 execCommand = execParser opts

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -2,6 +2,7 @@ module Config (Config (..)) where
 
 import Cardano.Api (NetworkId)
 import Ledger.Address (Address)
+import Ledger.Value (AssetClass)
 import Prelude
 
 data Config = Config
@@ -12,6 +13,8 @@ data Config = Config
   , usePubKeys :: !Bool
   , ownAddress :: !Address
   , signingKeyFile :: !FilePath
+  , assetClass :: !(Maybe AssetClass)
+  , dropAmount :: !(Maybe Integer)
   , -- | Grouping multiple beneficiaries to a single transaction for optimising fees
     beneficiaryPerTx :: !Int
   , -- | Dry run mode will build the tx, but skip the submit step

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -2,14 +2,12 @@ module Config (Config (..)) where
 
 import Cardano.Api (NetworkId)
 import Ledger.Address (Address)
-import Ledger.Value (AssetClass)
 import Prelude
 
 data Config = Config
   { network :: !NetworkId
   , -- | Protocol params file location relative to the cardano-cli working directory (needed for the cli)
     protocolParamsFile :: !FilePath
-  , assetClass :: !AssetClass
   , beneficiariesFile :: !FilePath
   , usePubKeys :: !Bool
   , ownAddress :: !Address

--- a/src/TokenAirdrop.hs
+++ b/src/TokenAirdrop.hs
@@ -25,6 +25,7 @@ tokenAirdrop config = do
               )
               beneficiaries
 
+  print beneficiaries
   mapM
     ( \tx -> do
         utxos <- utxosAt config $ config.ownAddress

--- a/src/TokenAirdrop.hs
+++ b/src/TokenAirdrop.hs
@@ -20,7 +20,7 @@ tokenAirdrop config = do
           group config.beneficiaryPerTx $
             map
               ( \beneficiary ->
-                  let val = Value.assetClassValue config.assetClass beneficiary.amount
+                  let val = Value.assetClassValue beneficiary.assetClass beneficiary.amount
                    in Constraints.mustPayToPubKey beneficiary.address.pkaPubKeyHash val
               )
               beneficiaries

--- a/test/Spec/FakePAB/Address.hs
+++ b/test/Spec/FakePAB/Address.hs
@@ -11,7 +11,6 @@ import Ledger qualified
 import Ledger.Address (Address (..))
 import Ledger.Credential (Credential (..), StakingCredential (..))
 import Ledger.Crypto (PubKey)
-import Ledger.Value qualified as Value
 import Plutus.PAB.Arbitrary ()
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
@@ -71,7 +70,6 @@ defaultConfig =
   Config
     { network = Testnet (NetworkMagic 100)
     , protocolParamsFile = "./protocol.json"
-    , assetClass = Value.assetClass "adc123" "testtoken"
     , beneficiariesFile = "./beneficiaries"
     , usePubKeys = True
     , ownAddress = Ledger.pubKeyHashAddress "aabb1122"

--- a/test/Spec/FakePAB/Address.hs
+++ b/test/Spec/FakePAB/Address.hs
@@ -11,6 +11,7 @@ import Ledger qualified
 import Ledger.Address (Address (..))
 import Ledger.Credential (Credential (..), StakingCredential (..))
 import Ledger.Crypto (PubKey)
+import Ledger.Value qualified as Value
 import Plutus.PAB.Arbitrary ()
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
@@ -74,6 +75,8 @@ defaultConfig =
     , usePubKeys = True
     , ownAddress = Ledger.pubKeyHashAddress "aabb1122"
     , signingKeyFile = "./own.skey"
+    , assetClass = Just $ Value.assetClass "adc123" "testtoken"
+    , dropAmount = Just 4
     , beneficiaryPerTx = 100
     , dryRun = True
     , minLovelaces = 100

--- a/token-airdrop.cabal
+++ b/token-airdrop.cabal
@@ -116,6 +116,7 @@ library
     , prettyprinter
     , process
     , row-types
+    , safe
     , serialise
     , split
     , stm


### PR DESCRIPTION
Removing the `--asset-class` cli option and using a 3rd column in the beneficiaries file with the asset class.
Addressing: https://github.com/mlabs-haskell/CardStarter-bulk-airdrop-script/issues/1
