### PR TITLE
Sam/various fixes

### DIFF
--- a/src/BeneficiariesFile.hs
+++ b/src/BeneficiariesFile.hs
@@ -37,21 +37,21 @@ parseBeneficiary conf = toBeneficiary . words
   where
     toBeneficiary :: [Text] -> Either Text Beneficiary
     toBeneficiary [addr, amt, ac] =
-      makeBenficiary addr (parseAmt amt) (parseAsset ac)
+      makeBeneficiary addr (parseAmt amt) (parseAsset ac)
     -- Second arg could be amount or asset class, so we try to parse as asset first, if not, then amount
     -- Then fill in the Beneficiary with the data we have left, failing if we're missing anything
     toBeneficiary [addr, assetOrAmt] = do
       eAssetOrAmt <- parseAssetOrAmt assetOrAmt
-      makeBenficiary
+      makeBeneficiary
         addr
         (maybeToMissing "quantity" $ flip fromRight eAssetOrAmt <$> conf.dropAmount)
         (maybeToMissing "assetclass" $ flip fromLeft eAssetOrAmt <$> conf.assetClass)
     toBeneficiary [addr] =
-      makeBenficiary addr (maybeToMissing "quantity" conf.dropAmount) (maybeToMissing "assetclass" conf.assetClass)
+      makeBeneficiary addr (maybeToMissing "quantity" conf.dropAmount) (maybeToMissing "assetclass" conf.assetClass)
     toBeneficiary _ = Left "Invalid number of inputs"
 
-    makeBenficiary :: Text -> Either Text Integer -> Either Text AssetClass -> Either Text Beneficiary
-    makeBenficiary addr eAmt eAc = Beneficiary <$> parseAddress conf.usePubKeys addr <*> eAmt <*> eAc
+    makeBeneficiary :: Text -> Either Text Integer -> Either Text AssetClass -> Either Text Beneficiary
+    makeBeneficiary addr eAmt eAc = Beneficiary <$> parseAddress conf.usePubKeys addr <*> eAmt <*> eAc
 
 maybeToMissing :: Text -> Maybe a -> Either Text a
 maybeToMissing name = maybeToRight ("Missing " <> name)

--- a/src/BeneficiariesFile.hs
+++ b/src/BeneficiariesFile.hs
@@ -52,13 +52,14 @@ parseAmt cliArg rawStr =
 -- Otherwise, incorrect order of arguments would silently do the wrong thing
 parseAssetEither :: Maybe AssetClass -> [Text] -> Either Text AssetClass
 parseAssetEither cliArg _ = return $ fromJust cliArg
-  -- if isJust mAsset1 && isJust thirdTxt
-  --   then Left "Invalid argument order"
-  --   else maybeToRight "Invalid asset class" $ mAsset1 <|> mAsset2 <|> cliArg
-  -- where
-  --   mAsset1 = parseAsset $ strs `atMay` 1
-  --   thirdTxt = strs `atMay` 2
-  --   mAsset2 = parseAsset thirdTxt
+
+-- if isJust mAsset1 && isJust thirdTxt
+--   then Left "Invalid argument order"
+--   else maybeToRight "Invalid asset class" $ mAsset1 <|> mAsset2 <|> cliArg
+-- where
+--   mAsset1 = parseAsset $ strs `atMay` 1
+--   thirdTxt = strs `atMay` 2
+--   mAsset2 = parseAsset thirdTxt
 
 parseAsset :: Maybe Text -> Maybe AssetClass
 parseAsset rawStr = do

--- a/src/BeneficiariesFile.hs
+++ b/src/BeneficiariesFile.hs
@@ -1,11 +1,10 @@
 module BeneficiariesFile (readBeneficiariesFile, Beneficiary (..), parseAsset) where
 
 import Config (Config (..))
-import Control.Applicative ((<|>))
 import Data.Aeson.Extras (tryDecode)
 import Data.Attoparsec.Text qualified as Attoparsec
-import Data.Either.Combinators (mapLeft, maybeToRight, rightToMaybe)
-import Data.Maybe (fromJust)
+import Data.Bifunctor (first)
+import Data.Either.Combinators (fromLeft, fromRight, maybeToRight)
 import Data.Text (Text, lines, words)
 import Data.Text qualified as Text
 import Data.Text.IO (readFile)
@@ -15,7 +14,6 @@ import Ledger qualified
 import Ledger.Crypto (PubKeyHash (..))
 import Ledger.Value (AssetClass)
 import PlutusTx.Builtins (toBuiltin)
-import Safe (atMay)
 import Text.Read (readMaybe)
 import Prelude hiding (lines, readFile, words)
 
@@ -30,7 +28,7 @@ instance Show Beneficiary where
 
 parseContent :: Config -> Text -> Either Text [Beneficiary]
 parseContent conf =
-  mapLeft ("Beneficiaries file parse error: " <>)
+  first ("Beneficiaries file parse error: " <>)
     . traverse (parseBeneficiary conf)
     . lines
 
@@ -38,51 +36,50 @@ parseBeneficiary :: Config -> Text -> Either Text Beneficiary
 parseBeneficiary conf = toBeneficiary . words
   where
     toBeneficiary :: [Text] -> Either Text Beneficiary
-    toBeneficiary strs =
-      Beneficiary
-        <$> parseAddress conf.usePubKeys (strs `atMay` 0)
-        <*> maybeToRight "Invalid amount" (parseAmt conf.dropAmount (strs `atMay` 1))
-        <*> parseAssetEither conf.assetClass strs
+    toBeneficiary [addr, amt, ac] =
+      makeBenficiary addr (parseAmt amt) (parseAsset ac)
+    -- Second arg could be amount or asset class, so we try to parse as asset first, if not, then amount
+    -- Then fill in the Beneficiary with the data we have left, failing if we're missing anything
+    toBeneficiary [addr, assetOrAmt] = do
+      eAssetOrAmt <- parseAssetOrAmt assetOrAmt
+      makeBenficiary
+        addr
+        (maybeToMissing "quantity" $ flip fromRight eAssetOrAmt <$> conf.dropAmount)
+        (maybeToMissing "assetclass" $ flip fromLeft eAssetOrAmt <$> conf.assetClass)
+    toBeneficiary [addr] =
+      makeBenficiary addr (maybeToMissing "quantity" conf.dropAmount) (maybeToMissing "assetclass" conf.assetClass)
+    toBeneficiary _ = Left "Invalid number of inputs"
 
-parseAmt :: Maybe Integer -> Maybe Text -> Maybe Integer
-parseAmt cliArg rawStr =
-  (readMaybe . Text.unpack =<< rawStr) <|> cliArg
+    makeBenficiary :: Text -> Either Text Integer -> Either Text AssetClass -> Either Text Beneficiary
+    makeBenficiary addr eAmt eAc = Beneficiary <$> parseAddress conf.usePubKeys addr <*> eAmt <*> eAc
 
--- Parses the asset in either position 1 or 2, errors if pos 1 is valid and 2 isn't empty
--- Otherwise, incorrect order of arguments would silently do the wrong thing
-parseAssetEither :: Maybe AssetClass -> [Text] -> Either Text AssetClass
-parseAssetEither cliArg _ = return $ fromJust cliArg
+maybeToMissing :: Text -> Maybe a -> Either Text a
+maybeToMissing name = maybeToRight ("Missing " <> name)
 
--- if isJust mAsset1 && isJust thirdTxt
---   then Left "Invalid argument order"
---   else maybeToRight "Invalid asset class" $ mAsset1 <|> mAsset2 <|> cliArg
--- where
---   mAsset1 = parseAsset $ strs `atMay` 1
---   thirdTxt = strs `atMay` 2
---   mAsset2 = parseAsset thirdTxt
+parseAmt :: Text -> Either Text Integer
+parseAmt = maybeToRight "Invalid amount" . readMaybe . Text.unpack
 
-parseAsset :: Maybe Text -> Maybe AssetClass
-parseAsset rawStr = do
-  str <- rawStr
-  rightToMaybe $ Attoparsec.parseOnly UtxoParser.assetClassParser str
+parseAssetOrAmt :: Text -> Either Text (Either AssetClass Integer)
+parseAssetOrAmt str = (Left <$> parseAsset str) <> (Right <$> parseAmt str)
 
-parseAddress :: Bool -> Maybe Text -> Either Text PubKeyAddress
-parseAddress isPubKey maybeAddrStr =
+parseAsset :: Text -> Either Text AssetClass
+parseAsset = first Text.pack . Attoparsec.parseOnly UtxoParser.assetClassParser
+
+parseAddress :: Bool -> Text -> Either Text PubKeyAddress
+parseAddress isPubKey addrStr =
   if isPubKey
     then do
-      addrStr <- maybeToRight "Invalid address" maybeAddrStr
       pkh <- parsePubKeyHash' addrStr
       toPubKeyAddress' $ Ledger.pubKeyHashAddress pkh
     else do
-      addrStr <- maybeToRight "Invalid address" maybeAddrStr
       addr <- deserialiseAddress addrStr
       toPubKeyAddress' addr
   where
-    toPubKeyAddress' = maybeToRight ("Script addresses are not allowed: " <> fromJust maybeAddrStr) . toPubKeyAddress
+    toPubKeyAddress' = maybeToRight ("Script addresses are not allowed: " <> addrStr) . toPubKeyAddress
 
 parsePubKeyHash' :: Text -> Either Text PubKeyHash
 parsePubKeyHash' rawStr =
-  PubKeyHash . toBuiltin <$> mapLeft Text.pack (tryDecode rawStr)
+  PubKeyHash . toBuiltin <$> first Text.pack (tryDecode rawStr)
 
 readBeneficiariesFile :: Config -> IO [Beneficiary]
 readBeneficiariesFile conf = do

--- a/src/BeneficiariesFile.hs
+++ b/src/BeneficiariesFile.hs
@@ -1,11 +1,11 @@
-module BeneficiariesFile (readBeneficiariesFile, Beneficiary (..)) where
+module BeneficiariesFile (readBeneficiariesFile, Beneficiary (..), parseAsset) where
 
 import Config (Config (..))
 import Control.Applicative ((<|>))
 import Data.Aeson.Extras (tryDecode)
 import Data.Attoparsec.Text qualified as Attoparsec
 import Data.Either.Combinators (mapLeft, maybeToRight, rightToMaybe)
-import Data.Maybe (isJust)
+import Data.Maybe (fromJust)
 import Data.Text (Text, lines, words)
 import Data.Text qualified as Text
 import Data.Text.IO (readFile)
@@ -51,14 +51,14 @@ parseAmt cliArg rawStr =
 -- Parses the asset in either position 1 or 2, errors if pos 1 is valid and 2 isn't empty
 -- Otherwise, incorrect order of arguments would silently do the wrong thing
 parseAssetEither :: Maybe AssetClass -> [Text] -> Either Text AssetClass
-parseAssetEither cliArg strs =
-  if isJust mAsset1 && isJust thirdTxt
-    then Left "Invalid argument order"
-    else maybeToRight "Invalid asset class" $ mAsset1 <|> mAsset2 <|> cliArg
-  where
-    mAsset1 = parseAsset $ strs `atMay` 1
-    thirdTxt = strs `atMay` 2
-    mAsset2 = parseAsset thirdTxt
+parseAssetEither cliArg _ = return $ fromJust cliArg
+  -- if isJust mAsset1 && isJust thirdTxt
+  --   then Left "Invalid argument order"
+  --   else maybeToRight "Invalid asset class" $ mAsset1 <|> mAsset2 <|> cliArg
+  -- where
+  --   mAsset1 = parseAsset $ strs `atMay` 1
+  --   thirdTxt = strs `atMay` 2
+  --   mAsset2 = parseAsset thirdTxt
 
 parseAsset :: Maybe Text -> Maybe AssetClass
 parseAsset rawStr = do
@@ -77,7 +77,7 @@ parseAddress isPubKey maybeAddrStr =
       addr <- deserialiseAddress addrStr
       toPubKeyAddress' addr
   where
-    toPubKeyAddress' = maybeToRight "Script addresses are not allowed" . toPubKeyAddress
+    toPubKeyAddress' = maybeToRight ("Script addresses are not allowed: " <> fromJust maybeAddrStr) . toPubKeyAddress
 
 parsePubKeyHash' :: Text -> Either Text PubKeyHash
 parsePubKeyHash' rawStr =

--- a/src/CommandLine.hs
+++ b/src/CommandLine.hs
@@ -53,6 +53,7 @@ configParser =
     <*> pDryRun
     <*> pMinLovelaces
     <*> pFees
+    <*> pVerbose
 
 opts :: ParserInfo Config
 opts =
@@ -163,6 +164,11 @@ pFees =
     ( long "fees" <> help "Transaction fees (used for coin selection)"
         <> metavar "NATURAL"
     )
+
+pVerbose :: Parser Bool
+pVerbose =
+  switch
+    (long "verbose" <> help "Log more details about the drop process")
 
 execCommand :: IO Config
 execCommand = execParser opts

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -21,5 +21,6 @@ data Config = Config
     dryRun :: !Bool
   , minLovelaces :: Integer
   , fees :: Integer
+  , verbose :: !Bool
   }
   deriving (Show)

--- a/src/FakePAB/Address.hs
+++ b/src/FakePAB/Address.hs
@@ -8,38 +8,65 @@ module FakePAB.Address (
   deserialiseAddress,
 ) where
 
-import Cardano.Api (AsType (AsAddressInEra, AsAlonzoEra))
-import Cardano.Api qualified
+import Cardano.Api (AsType (AsAddressInEra, AsAlonzoEra, AsByronEra), IsCardanoEra)
+import Cardano.Api qualified as CAPI
+import Cardano.Api.Byron qualified as CAPI
+import Cardano.Chain.Common (decodeAddressBase58)
+import Cardano.Prelude (decodeUtf8)
 import Config (Config)
+import Data.ByteArray (length)
 import Data.Either.Combinators (mapLeft, maybeToRight)
+import Data.Kind (Type)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Ledger.Address (Address (..))
 import Ledger.Credential (Credential (..), StakingCredential)
-import Ledger.Crypto (PubKeyHash)
+import Ledger.Crypto (PubKeyHash (PubKeyHash))
 import Plutus.Contract.CardanoAPI (fromCardanoAddress, toCardanoAddress)
-import Prelude
+import PlutusCore.Pretty (Pretty (pretty))
+import PlutusTx.Prelude qualified as PlutusTx
+import Prelude hiding (length)
 
 {- | Serialise an address to the bech32 form
  For more details on the different address types see: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0019/CIP-0019.md
 -}
 serialiseAddress :: Config -> Address -> Either Text Text
-serialiseAddress config address =
-  mapLeft (const "Couldn't create address") $
-    Cardano.Api.serialiseAddress
-      <$> toCardanoAddress config.network address
+serialiseAddress _ address@(Address (PubKeyCredential (PubKeyHash bytes)) _)
+  | length bytes > 28 =
+    -- When serialised from Byron, the pubkeyhashes are much longer than Alonzo era address pubkeyhashes
+    CAPI.serialiseAddress <$> serialiseByronAddress address
+serialiseAddress config address = CAPI.serialiseAddress <$> serialiseAlonzoAddress config address
+
+serialiseByronAddress :: Address -> Either Text (CAPI.AddressInEra CAPI.ByronEra)
+serialiseByronAddress (Address (PubKeyCredential (PubKeyHash bytes)) _) = do
+  b58 <-
+    mapLeft (Text.pack . show) $
+      decodeAddressBase58 $ decodeUtf8 $ PlutusTx.fromBuiltin bytes
+  pure $ CAPI.AddressInEra CAPI.ByronAddressInAnyEra (CAPI.ByronAddress b58)
+serialiseByronAddress _ = Left "Invalid Byron address"
+
+serialiseAlonzoAddress :: Config -> Address -> Either Text (CAPI.AddressInEra CAPI.AlonzoEra)
+serialiseAlonzoAddress config address = do
+  mapLeft (\err -> (Text.pack . show . pretty $ err) <> "\n" <> (Text.pack . show $ address)) $
+    toCardanoAddress config.network address
 
 unsafeSerialiseAddress :: Config -> Address -> Text
 unsafeSerialiseAddress config address =
   either (error . Text.unpack) id $ serialiseAddress config address
 
 deserialiseAddress :: Text -> Either Text Address
-deserialiseAddress addr = do
+deserialiseAddress addr =
+  if "addr" `Text.isPrefixOf` addr
+    then deserialiseAddress' AsAlonzoEra addr
+    else deserialiseAddress' AsByronEra addr
+
+deserialiseAddress' :: forall (era :: Type). IsCardanoEra era => AsType era -> Text -> Either Text Address
+deserialiseAddress' eraType addr = do
   cardanoAddr <-
     maybeToRight "Couldn't deserialise address" $
-      Cardano.Api.deserialiseAddress (AsAddressInEra AsAlonzoEra) addr
+      CAPI.deserialiseAddress (AsAddressInEra eraType) addr
 
-  mapLeft (const "Couldn't convert address") $ fromCardanoAddress cardanoAddr
+  mapLeft (const "Couldn't convert deserialised address") $ fromCardanoAddress cardanoAddr
 
 unsafeDeserialiseAddress :: Text -> Address
 unsafeDeserialiseAddress address =

--- a/src/FakePAB/CardanoCLI.hs
+++ b/src/FakePAB/CardanoCLI.hs
@@ -15,7 +15,7 @@ import Data.Aeson qualified as JSON
 import Data.Aeson.Extras (encodeByteString)
 import Data.Attoparsec.Text (parseOnly)
 import Data.ByteString.Lazy.Char8 qualified as Char8
-import Data.Either.Combinators (rightToMaybe)
+import Data.Either.Combinators (fromRight, rightToMaybe)
 import Data.List (sort)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -58,7 +58,7 @@ callCommand ShellCommand {cmdName, cmdArgs, cmdOutParser} =
 {- | Submit a transaction by calling cardano-cli commands
  Returns an error message if submitting the transaction fails.
 -}
-submitScript :: Config -> UnbalancedTx -> IO (Either Text ())
+submitScript :: Config -> UnbalancedTx -> IO (Either Text TxId)
 submitScript config UnbalancedTx {unBalancedTxTx, unBalancedTxUtxoIndex} = do
   -- Configuration
   let ownAddr = config.ownAddress
@@ -75,10 +75,15 @@ submitScript config UnbalancedTx {unBalancedTxTx, unBalancedTxUtxoIndex} = do
       createDirectoryIfMissing False "txs"
       buildTx config ownAddr preparedTx
       signTx preparedTx config.signingKeyFile
+      txId <- getCLITxId preparedTx
 
       if config.dryRun
-        then pure $ Right ()
-        else submitTx preparedTx config
+        then do
+          putStrLn "Dry run, not submitting transaction"
+          pure $ Right txId
+        else do
+          putStrLn "Submitting transaction"
+          fmap (txId <$) $ submitTx preparedTx config
 
 data Tip = Tip
   { epoch :: Integer
@@ -119,6 +124,17 @@ utxosAt config address = do
   where
     toUtxo :: Text -> Either String (TxOutRef, ChainIndexTxOut)
     toUtxo line = parseOnly (UtxoParser.utxoMapParser address) line
+
+-- | Gets the transaction ID as reported from the CLI - for this can differ due to CLI's balancing
+getCLITxId :: Tx -> IO TxId
+getCLITxId tx = do
+  callCommand $ ShellCommand "cardano-cli" opts (fromRight "" . parseOnly UtxoParser.txIdParser . Text.pack)
+  where
+    opts =
+      mconcat
+        [ ["transaction", "txid" ]
+        , ["--tx-body-file", txToFileName "raw" tx ]
+        ]
 
 -- | Build a tx body and write it to disk
 buildTx :: Config -> Address -> Tx -> IO ()

--- a/src/FakePAB/CardanoCLI.hs
+++ b/src/FakePAB/CardanoCLI.hs
@@ -7,6 +7,7 @@ module FakePAB.CardanoCLI (
   queryTip,
   utxosAt,
   submitScript,
+  getCLITxIdFromFile,
 ) where
 
 import Cardano.Api.Shelley (NetworkId (Mainnet, Testnet), NetworkMagic (..))
@@ -127,13 +128,16 @@ utxosAt config address = do
 
 -- | Gets the transaction ID as reported from the CLI - for this can differ due to CLI's balancing
 getCLITxId :: Tx -> IO TxId
-getCLITxId tx = do
+getCLITxId = getCLITxIdFromFile . txToFileName "raw"
+
+getCLITxIdFromFile :: Text -> IO TxId
+getCLITxIdFromFile txPath = do
   callCommand $ ShellCommand "cardano-cli" opts (fromRight "" . parseOnly UtxoParser.txIdParser . Text.pack)
   where
     opts =
       mconcat
         [ ["transaction", "txid"]
-        , ["--tx-body-file", txToFileName "raw" tx]
+        , ["--tx-body-file", txPath]
         ]
 
 -- | Build a tx body and write it to disk

--- a/src/FakePAB/CardanoCLI.hs
+++ b/src/FakePAB/CardanoCLI.hs
@@ -79,10 +79,10 @@ submitScript config UnbalancedTx {unBalancedTxTx, unBalancedTxUtxoIndex} = do
 
       if config.dryRun
         then do
-          putStrLn "Dry run, not submitting transaction"
+          putStrLn $ "Dry run, not submitting transaction: " <> show txId
           pure $ Right txId
         else do
-          putStrLn "Submitting transaction"
+          putStrLn $ "Submitting transaction: " <> show txId
           fmap (txId <$) $ submitTx preparedTx config
 
 data Tip = Tip

--- a/src/FakePAB/CardanoCLI.hs
+++ b/src/FakePAB/CardanoCLI.hs
@@ -132,8 +132,8 @@ getCLITxId tx = do
   where
     opts =
       mconcat
-        [ ["transaction", "txid" ]
-        , ["--tx-body-file", txToFileName "raw" tx ]
+        [ ["transaction", "txid"]
+        , ["--tx-body-file", txToFileName "raw" tx]
         ]
 
 -- | Build a tx body and write it to disk

--- a/src/FakePAB/Constraints.hs
+++ b/src/FakePAB/Constraints.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
-module FakePAB.Constraints (submitTx, waitNSlots) where
+module FakePAB.Constraints (submitTx, waitNSlots, logRecipientsUtxos) where
 
 import Config (Config)
 import Control.Concurrent (threadDelay)
@@ -47,11 +47,11 @@ submitTx config addressMap lookups constraints = do
       let tx' = useFullAddresses addressMap tx
 
       result <- submitScript config unbalancedTx {unBalancedTxTx = tx'}
-      -- Wait 40 seconds for the next block
+      -- Wait 60 seconds for the next block
 
       putStrLn "Tx submitted, waiting for next block..."
-      waitNSlots config 1
-      logRecipientsUtxos config tx'
+      waitNSlots config 60
+
       pure result
 
 -- | Replaces

--- a/src/FakePAB/Constraints.hs
+++ b/src/FakePAB/Constraints.hs
@@ -24,6 +24,7 @@ import Ledger.Tx (ChainIndexTxOut (..), Tx (..), TxOutRef (..))
 import Ledger.Tx qualified as Tx
 import Ledger.Typed.Scripts.Validators (DatumType, RedeemerType)
 import Ledger.Value qualified as Value
+import Plutus.V1.Ledger.Api (TxId)
 import PlutusTx (FromData, ToData)
 import PlutusTx.Builtins (fromBuiltin)
 import Prelude
@@ -35,7 +36,7 @@ submitTx ::
   Map PubKeyHash PubKeyAddress ->
   ScriptLookups a ->
   TxConstraints (RedeemerType a) (DatumType a) ->
-  IO (Either Text ())
+  IO (Either Text TxId)
 submitTx config addressMap lookups constraints = do
   putStrLn "Starting contract"
   let eitherUnbalancedTx = mkTx lookups constraints
@@ -46,13 +47,7 @@ submitTx config addressMap lookups constraints = do
     Right unbalancedTx@UnbalancedTx {unBalancedTxTx = tx} -> do
       let tx' = useFullAddresses addressMap tx
 
-      result <- submitScript config unbalancedTx {unBalancedTxTx = tx'}
-      -- Wait 60 seconds for the next block
-
-      putStrLn "Tx submitted, waiting for next block..."
-      waitNSlots config 60
-
-      pure result
+      submitScript config unbalancedTx {unBalancedTxTx = tx'}
 
 -- | Replaces
 useFullAddresses :: Map PubKeyHash PubKeyAddress -> Tx -> Tx

--- a/src/FakePAB/UtxoParser.hs
+++ b/src/FakePAB/UtxoParser.hs
@@ -2,6 +2,7 @@ module FakePAB.UtxoParser (
   chainIndexTxOutParser,
   utxoMapParser,
   assetClassParser,
+  txIdParser,
 ) where
 
 import Control.Applicative ((<|>))
@@ -43,11 +44,14 @@ utxoMapParser address =
 
 txOutRefParser :: Parser TxOutRef
 txOutRefParser = do
-  txId <- TxId <$> decodeHash (takeWhile (/= ' '))
+  txId <- txIdParser
 
   skipSpace
   txIx <- decimal
   pure $ TxOutRef txId txIx
+
+txIdParser :: Parser TxId
+txIdParser = TxId <$> decodeHash (takeWhile (/= ' '))
 
 chainIndexTxOutParser :: Address -> Parser ChainIndexTxOut
 chainIndexTxOutParser address = do

--- a/src/FakePAB/UtxoParser.hs
+++ b/src/FakePAB/UtxoParser.hs
@@ -19,6 +19,7 @@ import Data.Attoparsec.Text (
   take,
   takeWhile,
  )
+import Data.Char (isSpace)
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
 import Ledger (Address (addressCredential))
@@ -52,7 +53,7 @@ txOutRefParser = do
   pure $ TxOutRef txId txIx
 
 txIdParser :: Parser TxId
-txIdParser = TxId <$> decodeHash (takeWhile (\c -> c /= ' ' && c /= '\n'))
+txIdParser = TxId <$> decodeHash (takeWhile $ not . isSpace)
 
 chainIndexTxOutParser :: Address -> Parser ChainIndexTxOut
 chainIndexTxOutParser address = do

--- a/src/FakePAB/UtxoParser.hs
+++ b/src/FakePAB/UtxoParser.hs
@@ -51,7 +51,7 @@ txOutRefParser = do
   pure $ TxOutRef txId txIx
 
 txIdParser :: Parser TxId
-txIdParser = TxId <$> decodeHash (takeWhile (/= ' '))
+txIdParser = TxId <$> decodeHash (takeWhile (\c -> c /= ' ' && c /= '\n'))
 
 chainIndexTxOutParser :: Address -> Parser ChainIndexTxOut
 chainIndexTxOutParser address = do

--- a/src/FakePAB/UtxoParser.hs
+++ b/src/FakePAB/UtxoParser.hs
@@ -16,6 +16,7 @@ import Data.Attoparsec.Text (
   sepBy,
   signed,
   skipSpace,
+  take,
   takeWhile,
  )
 import Data.Text (Text)
@@ -36,7 +37,7 @@ import Plutus.V1.Ledger.Api (
   CurrencySymbol (..),
  )
 import PlutusTx.Builtins (toBuiltin)
-import Prelude hiding (takeWhile)
+import Prelude hiding (take, takeWhile)
 
 utxoMapParser :: Address -> Parser (TxOutRef, ChainIndexTxOut)
 utxoMapParser address =
@@ -79,10 +80,10 @@ assetClassParser =
   where
     adaAssetClass = Value.assetClass Ada.adaSymbol Ada.adaToken <$ "lovelace"
     noNameAsset = do
-      curSymbol <- CurrencySymbol <$> decodeHash (takeWhile (/= ' '))
+      curSymbol <- CurrencySymbol <$> decodeHash (take 56)
       pure $ Value.assetClass curSymbol ""
     otherAssetClass = do
-      curSymbol <- CurrencySymbol <$> decodeHash (takeWhile (/= '.'))
+      curSymbol <- CurrencySymbol <$> decodeHash (take 56)
       void $ char '.'
       tokenName <- Value.tokenName . encodeUtf8 <$> takeWhile (/= ' ')
       pure $ Value.assetClass curSymbol tokenName

--- a/src/TokenAirdrop.hs
+++ b/src/TokenAirdrop.hs
@@ -7,7 +7,7 @@ import Data.Text (Text)
 import Data.Void (Void)
 import FakePAB.Address (PubKeyAddress (pkaPubKeyHash))
 import FakePAB.CardanoCLI (utxosAt)
-import FakePAB.Constraints (submitTx)
+import FakePAB.Constraints (submitTx, waitNSlots)
 import Ledger.Constraints qualified as Constraints
 import Ledger.Crypto (PubKeyHash)
 import Ledger.Value qualified as Value
@@ -43,7 +43,12 @@ tokenAirdrop config = do
         utxos <- utxosAt config $ config.ownAddress
         let lookups = Constraints.unspentOutputs utxos
 
-        submitTx @Void config pubKeyAddressMap lookups tx
+        eTxId <- submitTx @Void config pubKeyAddressMap lookups tx
+        -- Wait 60 seconds for the next block
+        putStrLn "Tx submitted, waiting for next block..."
+
+        waitNSlots config 60
+        return $ () <$ eTxId
     )
     $ zipWith combine2To3 txPairs [1 :: Int ..]
 

--- a/src/TokenAirdrop.hs
+++ b/src/TokenAirdrop.hs
@@ -65,7 +65,7 @@ tokenAirdrop config = do
 -- | Repeatedly waits a block until we have the inputs we need
 waitUntilHasTxIn :: Config -> Integer -> TxId -> IO ()
 waitUntilHasTxIn config n txId = do
-  when (n > blockCountWarning) $ putStrLn "WARNING: Waited over 50 blocks for transaction to land, it may have failed. (Continuing to wait)"
+  when (n >= blockCountWarning) . putStrLn $ "WARNING: Waited " ++ show n ++ " blocks for transaction to land, it may have failed. (Continuing to wait)"
   when config.verbose $ putStrLn "Waiting a block then checking own UTxOs..."
   waitNSlots config 20 -- Wait a block
   utxos <- utxosAt config $ config.ownAddress

--- a/src/TokenAirdrop.hs
+++ b/src/TokenAirdrop.hs
@@ -2,7 +2,7 @@ module TokenAirdrop (tokenAirdrop) where
 
 import BeneficiariesFile (Beneficiary (address), readBeneficiariesFile)
 import Config (Config (..))
-import Data.Map (Map, fromList)
+import Data.Map (Map, fromList, keys)
 import Data.Text (Text)
 import Data.Void (Void)
 import FakePAB.Address (PubKeyAddress (pkaPubKeyHash))
@@ -11,6 +11,7 @@ import FakePAB.Constraints (submitTx, waitNSlots)
 import Ledger.Constraints qualified as Constraints
 import Ledger.Crypto (PubKeyHash)
 import Ledger.Value qualified as Value
+import Plutus.V1.Ledger.Api (TxId, TxOutRef (txOutRefId))
 import Prelude
 
 tokenAirdrop :: Config -> IO (Either Text ())
@@ -28,7 +29,8 @@ tokenAirdrop config = do
               )
               beneficiaries
 
-  mapM_ (\(_, bs) -> mapM_ print bs >> putStrLn "==============") txPairs
+  -- Save Our Consoles
+  -- mapM_ (\(_, bs) -> mapM_ print bs >> putStrLn "==============") txPairs
 
   let addrs :: [PubKeyAddress]
       addrs = address <$> beneficiaries
@@ -44,13 +46,26 @@ tokenAirdrop config = do
         let lookups = Constraints.unspentOutputs utxos
 
         eTxId <- submitTx @Void config pubKeyAddressMap lookups tx
-        -- Wait 60 seconds for the next block
-        putStrLn "Tx submitted, waiting for next block..."
-
-        waitNSlots config 60
-        return $ () <$ eTxId
+        case eTxId of
+          Left err -> pure $ Left err
+          Right txId -> do
+            putStrLn $ "Submitted transaction successfully: " ++ show txId
+            waitUntilHasTxIn config txId
+            pure $ Right ()
     )
     $ zipWith combine2To3 txPairs [1 :: Int ..]
+
+-- | Repeatedly waits a block until we have the inputs we need
+waitUntilHasTxIn :: Config -> TxId -> IO ()
+waitUntilHasTxIn config txId = do
+  putStrLn "Waiting a block then checking own UTxOs..."
+  waitNSlots config 20 -- Wait a block
+  utxos <- utxosAt config $ config.ownAddress
+  if any ((== txId) . txOutRefId) (keys utxos)
+    then putStrLn "Found transaction output in own UTxOs, finished waiting."
+    else do
+      putStrLn "Couldn't find transaction output in own UTxOs, looping."
+      waitUntilHasTxIn config txId
 
 -- | mapM for IO Either that stops on Left
 mapMErr :: (a -> IO (Either Text ())) -> [a] -> IO (Either Text ())

--- a/test/Spec/FakePAB/Address.hs
+++ b/test/Spec/FakePAB/Address.hs
@@ -83,4 +83,5 @@ defaultConfig =
     , dryRun = True
     , minLovelaces = 100
     , fees = 100
+    , verbose = False
     }

--- a/test/Spec/FakePAB/Address.hs
+++ b/test/Spec/FakePAB/Address.hs
@@ -40,6 +40,8 @@ addressRoundtrip =
       , ("addr1vycujnqrkefsyse5hn445dw3s574s6kgafz0m2x8huj696sw0eckx", Mainnet)
       , ("addr_test1qqcujnqrkefsyse5hn445dw3s574s6kgafz0m2x8huj6964v98n5zvwqrkqwwe2l9dr90myy9v49x6uxnkw6m5as3jhssl70wh", Testnet (NetworkMagic 100))
       , ("addr1qx5zluvgkprgl2t4rw4a0gp2fu068wuf0uqjg0a2smzvxnln5dzfhe09chdz56nfnhshtx02laxklk5zzaw43yvjsnzspatnss", Mainnet)
+      , ("DdzFFzCqrhsiN3r1AkJPYLqi59ARDeq3aEou5u1baprxoDRD6oc2vw1ibfCgzaR6xpShQhiSvRfwXAGrN3HMiy21rTbKL6j9R5kQqzTs", Mainnet) -- First form of Byron address
+      , ("Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi", Mainnet) -- Second form of Byron address
       ]
 
 prop_AddressRoundtrip :: Address -> Config -> Property

--- a/token-airdrop.cabal
+++ b/token-airdrop.cabal
@@ -92,6 +92,7 @@ library
     , bytestring            ^>=0.10.12.0
     , cardano-api
     , cardano-crypto
+    , cardano-ledger-byron
     , cardano-prelude
     , containers
     , cryptonite


### PR DESCRIPTION
Fixes various issues found while using:

- Handles Byron era addresses
- Fixed issue with parsing beneficiaries file, where some quantities could be parsed as short asset classes without names
- Added the txId to the output
- Added better logging for transaction submission
- Change tx waiting to busy wait scaning utxos at address (final change to this, cannot fail™)
- Other little bits and bobs