### PR TITLE
Generate [Beneficiary] directly instead of generating and parsing Text.

### DIFF
--- a/src/FakePAB/CardanoCLI.hs
+++ b/src/FakePAB/CardanoCLI.hs
@@ -144,7 +144,7 @@ getCLITxIdFromFile txPath = do
 buildTx :: Config -> Address -> Tx -> IO ()
 buildTx config ownAddr tx = do
   writeFile (Text.unpack $ txToFileName "pre-encode" tx) (LazyText.unpack $ pShowNoColor tx)
-  callCommand $ ShellCommand "cardano-cli" opts (const ())
+  callCommand $ ShellCommand "cardano-cli" opts mempty
   where
     opts =
       mconcat
@@ -173,7 +173,7 @@ signTx tx signingKeyFile =
           , ["--out-file", txToFileName "signed" tx]
           ]
       )
-      (const ())
+      mempty
 
 -- Signs and writes a tx (uses the tx body written to disk as input)
 submitTx :: Tx -> Config -> IO (Either Text ())

--- a/src/TokenAirdrop.hs
+++ b/src/TokenAirdrop.hs
@@ -98,7 +98,7 @@ tokenAirdrop config = do
 
     writeLog :: FilePath -> Either Text Text -> IO ()
     writeLog path = \case
-      Left err -> error . unpack $ err
+      Left err -> error (unpack err)
       Right t -> do
         createDirectoryIfMissing True $ takeDirectory path
         writeFile path $ unpack t
@@ -111,8 +111,10 @@ tokenAirdrop config = do
 -- | Repeatedly waits a block until we have the inputs we need
 waitUntilHasTxIn :: Config -> Integer -> TxId -> IO ()
 waitUntilHasTxIn config n txId = do
-  when (n >= blockCountWarning) . putStrLn $ "WARNING: Waited " ++ show n ++ " blocks for transaction to land, it may have failed. (Continuing to wait)"
-  when config.verbose $ putStrLn "Waiting a block then checking own UTxOs..."
+  when (n >= blockCountWarning) do
+    putStrLn $ "WARNING: Waited " ++ show n ++ " blocks for transaction to land, it may have failed. (Continuing to wait)"
+  when config.verbose do
+    putStrLn "Waiting a block then checking own UTxOs..."
   waitNSlots config 20 -- Wait a block
   utxos <- utxosAt config $ config.ownAddress
   if any ((== txId) . txOutRefId) (keys utxos)
@@ -131,4 +133,5 @@ combine2To3 (a, b) = (a,b,)
 group :: Int -> [a] -> [[a]]
 group n list
   | length list <= n = [list]
-  | otherwise = let (xs, xss) = splitAt n list in xs : group n xss
+  | let (xs, xss) = splitAt n list =
+    xs : group n xss

--- a/test/Spec/BeneficiariesFile.hs
+++ b/test/Spec/BeneficiariesFile.hs
@@ -1,20 +1,23 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Spec.BeneficiariesFile (tests, defaultConfig) where
 
-import BeneficiariesFile (parseContent, prettyContent)
+import BeneficiariesFile (Beneficiary (..), parseContent, prettyContent, scaleAmount)
 import Cardano.Api (NetworkId (..), NetworkMagic (..))
 import Config (Config (..))
 import Control.Monad (guard, (>=>))
 import Data.Either (isLeft)
-import Data.Functor (($>))
-import Data.Maybe (catMaybes, isNothing)
 import Data.Scientific
-import Data.Text (Text, pack, unlines, unpack, unwords)
+import Data.String (fromString)
+import Data.Text (pack, unpack, unwords)
+import Ledger.Crypto (PubKeyHash (..))
+import Ledger.Value (AssetClass, CurrencySymbol, TokenName, tokenName)
 import Ledger.Value qualified as Value
 import Plutus.PAB.Arbitrary ()
-import Plutus.V1.Ledger.Address (pubKeyHashAddress)
+import Plutus.V1.Ledger.Address (Address (..), pubKeyHashAddress)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, testCase)
-import Test.Tasty.QuickCheck (Arbitrary (..), Gen, Large (..), Positive (..), Property, Small (..), elements, liftArbitrary, listOf1, property, testProperty, (===))
+import Test.Tasty.QuickCheck (Arbitrary (..), Gen, Large (..), Positive (..), Property, Small (..), elements, liftArbitrary, listOf1, oneof, property, testProperty, (===))
 import Prelude hiding (truncate, unlines, unwords)
 
 tests :: TestTree
@@ -24,7 +27,6 @@ tests =
     [ testProperty "Token amount truncation" prop_TokenAmountTruncation
     , testCase "Amount must be provided exactly once" oneAmount
     , testCase "AssetClass must be provided exactly once" oneAssetClass
-    , testProperty "BeneficiariesFile can parse without error (Text -> [Beneficiary])" prop_Parse
     , testProperty "BeneficiariesFile can print without error ([Beneficiary] -> Text)" prop_Print
     , testProperty "BeneficiariesFile roundtrip (Text -> [Beneficiary] -> Text)" prop_Roundtrip1
     , testProperty "BeneficiariesFile roundtrip ([Beneficiary] -> Text -> [Beneficiary])" prop_Roundtrip2
@@ -61,32 +63,24 @@ prop_TokenAmountTruncation (TokenAmount amt) (Positive dp) =
       didTruncate = isLeft $ parseContent (defaultConfig {decimalPlaces = toInteger dp, dropAmount = Nothing, assetClass = Nothing}) (pack s)
    in didTruncate === shouldTruncate
 
-prop_Parse :: Beneficiaries -> Property
-prop_Parse (Beneficiaries (bens, config)) = either (error . unpack) (const $ property True) $ parseContent config bens
-
--- TODO Generate [Beneficiary] directly, don't depend on parsing
 prop_Print :: Beneficiaries -> Property
-prop_Print (Beneficiaries (bens, config)) = either (error . unpack) (const $ property True) $ parseContent config bens >>= prettyContent config
+prop_Print (Beneficiaries bens config) = either (error . unpack) (const $ property True) $ prettyContent config bens
 
 prop_Roundtrip1 :: Beneficiaries -> Property
-prop_Roundtrip1 (Beneficiaries (bens, config)) =
-  -- We can't check for equality immediately from the incoming Text, as information can be lost during parsing.
-  -- Thus we initially parse and then print, and then do the roundtrip, as parse >=> print should be idempotent
-  let printed = either (error . unpack) id $ parseContent config bens >>= prettyContent config
+prop_Roundtrip1 (Beneficiaries bens config) =
+  let printed = either (error . unpack) id $ prettyContent config bens
       roundTrip = parseContent config >=> prettyContent config
    in roundTrip printed === Right printed
 
--- TODO Generate [Beneficiary] directly
 prop_Roundtrip2 :: Beneficiaries -> Property
-prop_Roundtrip2 (Beneficiaries (bens, config)) =
-  let parsed = either (error . unpack) id $ parseContent config bens
-      roundTrip = prettyContent config >=> parseContent config
-   in roundTrip parsed === Right parsed
+prop_Roundtrip2 (Beneficiaries bens config) =
+  let roundTrip = prettyContent config >=> parseContent config
+   in roundTrip bens === Right bens
 
 newtype TokenAmount = TokenAmount {unTokenAmount :: Scientific}
   deriving stock (Show)
 
-newtype Beneficiaries = Beneficiaries (Text, Config) deriving stock (Show)
+data Beneficiaries = Beneficiaries [Beneficiary] Config deriving stock (Show)
 
 instance Arbitrary TokenAmount where
   arbitrary = do
@@ -94,71 +88,81 @@ instance Arbitrary TokenAmount where
     Small scale <- arbitrary @(Small Int)
     pure . TokenAmount . normalize $ scientific (toInteger x) scale
 
-instance Arbitrary Beneficiaries where
+instance Arbitrary Config where
+  arbitrary :: Gen Config
   arbitrary = do
     usePK <- arbitrary @Bool
     Positive dp <- arbitrary @(Positive Integer)
-
     dropAmount' <- fmap unTokenAmount <$> arbitrary @(Maybe TokenAmount)
-    assetClass' <- liftArbitrary . pure $ Value.assetClass "adc123" "testtoken"
-    let config =
-          defaultConfig
-            { usePubKeys = usePK
-            , decimalPlaces = dp
-            , truncate = True
-            , dropAmount = dropAmount'
-            , assetClass = assetClass'
-            }
-    beneficiaries <- listOf1 $ beneficiary usePK (isNothing assetClass') (isNothing dropAmount')
-    pure $ Beneficiaries (unlines beneficiaries, config)
+    assetClass' <- liftArbitrary @Maybe . pure $ Value.assetClass "adc123" "testtoken"
+    pure
+      defaultConfig
+        { usePubKeys = usePK
+        , decimalPlaces = dp
+        , truncate = True
+        , dropAmount = dropAmount'
+        , assetClass = assetClass'
+        }
+
+instance Arbitrary Beneficiaries where
+  arbitrary :: Gen Beneficiaries
+  arbitrary = do
+    conf <- arbitrary @Config
+    beneficiaries <- listOf1 (beneficiary conf)
+    pure (Beneficiaries beneficiaries conf)
     where
-      beneficiary :: Bool -> Bool -> Bool -> Gen Text
-      beneficiary usePubKey addAssetClass addTokenAmount = do
-        let destination = if usePubKey then pkhs else addresses
-            tokenAmount =
-              pack . formatScientific Fixed Nothing . unTokenAmount <$> arbitrary
-            asset = do
-              symbol <- currencySymbols
-              addTokenName <- arbitrary @Bool
-              if addTokenName
-                then do
-                  tokenName <- tokenNames
-                  pure $ symbol <> "." <> tokenName
-                else pure symbol
-        unwords
-          <$> (sequence . catMaybes)
-            [ Just destination
-            , guard addTokenAmount $> tokenAmount
-            , guard addAssetClass $> asset
-            ]
+      beneficiary :: Config -> Gen Beneficiary
+      beneficiary conf = do
+        theDestination <- destination
 
-      addresses :: Gen Text
-      addresses =
-        elements
-          [ "addr_test1vpzm7yazemjns5plryg9yq9lkv9xzr432e88jsdqprty4fqhcw9d7"
-          , "addr_test1vqsk6udkq2a552prwtmpmfs8yqyluxlvgx6zy20tqjsglyctfkjrg"
-          , "addr_test1vz0vpcef37gsanrj8mtta9hkhfd3ja5ekq7mdjgays7wzlcwzmvf6"
-          , "addr_test1vq85t2h3k22emdh9l72dhv0cywlj2a5qc0rj8tpdf8uh23st77ahh"
-          ]
+        theDropAmount <- maybe conf.dropAmount tokenAmount pure
+        let theScaledDropAmount = case scaleAmount conf theDropAmount of
+              Left err -> error (unpack err)
+              Right n -> n
 
-      pkhs :: Gen Text
-      pkhs =
-        elements
-          [ "adfd87319bd09c9e3ea10b251ccb046f87c5440343157e348c3ac7bd"
-          , "e58973896cb0ae0273296cd407786e543d24a1c9e17931cc246d1bff"
-          , "35530c9f7d13efb3153aef891e583a2980a31d27517ebae1e97c7dab"
-          , "1c9f9e9d6042266e5978163298d566f98336a308df616bd7285cb592"
-          ]
+        theAssetClass <- maybe conf.assetClass asset pure
 
-      currencySymbols :: Gen Text
-      currencySymbols =
-        elements
-          [ "1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e"
-          , "3ccd653511eec65bbd30c3489f53471b017c829bd97d3a2ae81fb818"
-          ]
+        pure (Beneficiary theDestination theScaledDropAmount theAssetClass)
+        where
+          asset :: Gen AssetClass
+          asset =
+            Value.assetClass
+              <$> currencySymbols
+              <*> oneof
+                [ tokenNames
+                , pure ""
+                ]
 
-      tokenNames :: Gen Text
-      tokenNames = fmap pack . listOf1 $ elements (['a' .. 'z'] <> ['0' .. '9'])
+          tokenAmount :: Gen Scientific
+          tokenAmount = unTokenAmount <$> arbitrary @TokenAmount
+
+          destination :: Gen Address
+          destination = elements (pubKeyHashAddress <$> pubKeys)
+            where
+              pubKeys :: [PubKeyHash]
+              pubKeys
+                | conf.usePubKeys =
+                  [ "45bf13a2cee538503f19105200bfb30a610eb1564e7941a008d64aa4"
+                  , "216d71b602bb4a282372f61da6072009fe1bec41b42229eb04a08f93"
+                  , "9ec0e3298f910ecc723ed6be96f6ba5b197699b03db6c91d243ce17f"
+                  , "0f45aaf1b2959db6e5ff94dbb1f823bf257680c3c723ac2d49f97546"
+                  ]
+                | otherwise =
+                  [ "adfd87319bd09c9e3ea10b251ccb046f87c5440343157e348c3ac7bd"
+                  , "e58973896cb0ae0273296cd407786e543d24a1c9e17931cc246d1bff"
+                  , "35530c9f7d13efb3153aef891e583a2980a31d27517ebae1e97c7dab"
+                  , "1c9f9e9d6042266e5978163298d566f98336a308df616bd7285cb592"
+                  ]
+
+          currencySymbols :: Gen CurrencySymbol
+          currencySymbols =
+            elements
+              [ "1d6445ddeda578117f393848e685128f1e78ad0c4e48129c5964dc2e"
+              , "3ccd653511eec65bbd30c3489f53471b017c829bd97d3a2ae81fb818"
+              ]
+
+          tokenNames :: Gen TokenName
+          tokenNames = fmap (tokenName . fromString) . listOf1 $ elements (['a' .. 'z'] <> ['0' .. '9'])
 
 defaultConfig :: Config
 defaultConfig =

--- a/token-airdrop.cabal
+++ b/token-airdrop.cabal
@@ -36,6 +36,7 @@ common common-lang
     NoImplicitPrelude
     BangPatterns
     BinaryLiterals
+    BlockArguments
     ConstraintKinds
     DataKinds
     DeriveFunctor


### PR DESCRIPTION
For #32, `Arbitrary Beneficiaries` now generates a list of beneficiaries rather than text.